### PR TITLE
Installomator 9 can return app name

### DIFF
--- a/Lists/dialog-installomator.sh
+++ b/Lists/dialog-installomator.sh
@@ -42,7 +42,7 @@ fi
 
 # take an installomator label and output the full app name
 function label_to_name(){
-	#name=$(grep -A2 "${1})" "$installomator" | grep "name=" | head -1 | cut -d '"' -f2) # pre Installomatyor 9.0
+	#name=$(grep -A2 "${1})" "$installomator" | grep "name=" | head -1 | cut -d '"' -f2) # pre Installomator 9.0
 	name=$(${installomator} ${1} RETURN_LABEL_NAME=1 LOGGING=REQ | tail -1)
 	if [[ ! -z $name ]]; then
 		echo $name

--- a/Lists/dialog-installomator.sh
+++ b/Lists/dialog-installomator.sh
@@ -42,7 +42,8 @@ fi
 
 # take an installomator label and output the full app name
 function label_to_name(){
-	name=$(grep -A2 "${1})" "$installomator" | grep "name=" | awk -F '=' '{print $NF}')
+	#name=$(grep -A2 "${1})" "$installomator" | grep "name=" | head -1 | cut -d '"' -f2) # pre Installomatyor 9.0
+	name=$(${installomator} ${1} RETURN_LABEL_NAME=1 LOGGING=REQ | tail -1)
 	if [[ ! -z $name ]]; then
 		echo $name
 	else


### PR DESCRIPTION
If the current line would ask for "firefox", 4 lines would be returned, so I changed that line a bit. But for the purpose of returning an app name, we added a parameter to Installomator Mohave it only return the app name (as the last line of output).