### PR TITLE
Forgot the check

### DIFF
--- a/Lists/dialog-installomator.sh
+++ b/Lists/dialog-installomator.sh
@@ -44,7 +44,7 @@ fi
 function label_to_name(){
 	#name=$(grep -A2 "${1})" "$installomator" | grep "name=" | head -1 | cut -d '"' -f2) # pre Installomator 9.0
 	name=$(${installomator} ${1} RETURN_LABEL_NAME=1 LOGGING=REQ | tail -1)
-	if [[ ! -z $name ]]; then
+	if [[ "$itemName" != "#" ]]; then
 		echo $name
 	else
 		echo $1


### PR DESCRIPTION
Version 9 of Installomator will return "#" if the label was unknown. In that case we might not want to go forward with installation, but anyway…